### PR TITLE
Strip the extension when displaying a song name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The change log is available [on GitHub][2].
 * [#7](https://github.com/cronokirby/darby/issues/7)
   Make the CLI program shuffle and display a playlist
   of files in a directory.
+* [#9](https://github.com/cronokirby/darby/issues/9)
+  Strip the extension of songs when displaying them.
+  
 
 [1]: https://pvp.haskell.org
 [2]: https://github.com/cronokirby/darby/releases

--- a/darby.cabal
+++ b/darby.cabal
@@ -33,6 +33,7 @@ library
     , optparse-applicative >= 0.14.2 && < 0.15
     , random               >= 1.1    && < 1.2
     , relude               >= 0.4.0  && < 0.5
+    , text                 >= 1.2    && < 1.3
   default-language:    Haskell2010
   default-extensions:
       OverloadedStrings


### PR DESCRIPTION
resolves #9 

Adds a `songName` field to the `Song` record in order to distinguish the path of the song, and the name to be displayed. The new behavior of the program is to shuffle the list of songs, and display their names
without extensions.