### PR TITLE
Add an option to display songs without playing them

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ The change log is available [on GitHub][2].
 * [#17](https://github.com/cronokirby/darby/issues/17)
   Add a `noshuffle` option to not shuffle the songs
   before playing them.
+* [#16](https://github.com/cronokirby/darby/issues/16)
+  Add a `display` option to print out the songs without
+  playing them.
   
 
 [1]: https://pvp.haskell.org

--- a/src/Darby.hs
+++ b/src/Darby.hs
@@ -22,7 +22,10 @@ darby = do
     playlist <- if shuffle
         then playShuffle dir
         else playNoShuffle dir
-    liftIO . runMusicM $ playPlaylist playlist
+    display <- asks contextJustDisplay
+    if display
+        then displayPlaylist playlist
+        else liftIO . runMusicM $ playPlaylist playlist
   where
     readAndShuffle = readPlaylist >=> shufflePlaylist
     playShuffle :: FilePath -> ContextM Playlist

--- a/src/Darby/Context.hs
+++ b/src/Darby/Context.hs
@@ -26,6 +26,7 @@ to shuffle, but will be expanded later.
 data Context = Context
     { contextDirectory :: FilePath
     , contextShuffle :: Bool
+    , contextJustDisplay :: Bool
     }
 
 
@@ -35,6 +36,10 @@ contextParser = Context
     <*> flag True False
         (  long "noshuffle"
         <> help "Set this to not shuffle the songs"
+        )
+    <*> switch
+        (  long "display"
+        <> help "Print out the list without playing it"
         )
 
 argsParser :: ParserInfo Context


### PR DESCRIPTION
resolves #16 

Adds a `--display` option to darby to simply display the songs but not actually play them.