### PR TITLE
Display a progress bar when playing songs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,8 @@ The change log is available [on GitHub][2].
 * [#16](https://github.com/cronokirby/darby/issues/16)
   Add a `display` option to print out the songs without
   playing them.
+* [#18](https://github.com/cronokirby/darby/issues/18)
+  Add a progress bar to display when playing songs.
   
 
 [1]: https://pvp.haskell.org

--- a/darby.cabal
+++ b/darby.cabal
@@ -36,6 +36,7 @@ library
     , relude               >= 0.4.0  && < 0.5
     , sdl2                 >= 2.4    && < 2.5
     , sdl2-mixer           >= 1.1    && < 1.2
+    , taglib               >= 0.1    && < 0.2
     , text                 >= 1.2    && < 1.3
   default-language:    Haskell2010
   default-extensions:

--- a/darby.cabal
+++ b/darby.cabal
@@ -29,6 +29,7 @@ library
   ghc-options:         -Wall
   build-depends:       
       base-noprelude       >= 4.11   && < 5
+    , ansi-terminal        >= 0.8    && < 0.9
     , array                >= 0.5    && < 0.6
     , directory            >= 1.3    && < 1.4
     , optparse-applicative >= 0.14.2 && < 0.15

--- a/src/Darby/Music.hs
+++ b/src/Darby/Music.hs
@@ -63,21 +63,23 @@ playSong :: Song -> MusicM ()
 playSong song = do
     music <- Mix.load (songPath song)
     putTextLn ("Playing: " <> songName song)
-    printCompletion (songDuration song) 0
     Mix.playMusic Mix.Once music
-    delayWhile Mix.playingMusic
+    delayWhile Mix.playingMusic updateCompletion
     Mix.free music
+  where
+    updateCompletion = printCompletion (songDuration song)
 
 playPlaylist :: Playlist -> MusicM ()
 playPlaylist = mapM_ playSong . getPlaylist
 
 
 -- | Keeps spinning until the condition is false
-delayWhile :: MonadIO m => m Bool -> m ()
-delayWhile check = loop
+delayWhile :: MonadIO m => m Bool -> (Integer -> m ()) -> m ()
+delayWhile check action = loop 0
   where
-    loop = do
+    loop i = do
         still <- check
         when still $ do
-            SDL.delay 300
-            loop
+            action i
+            SDL.delay 1000
+            loop (i + 1)

--- a/src/Darby/Music.hs
+++ b/src/Darby/Music.hs
@@ -18,6 +18,7 @@ import Relude
 import Data.Text (justifyRight)
 import qualified SDL
 import qualified SDL.Mixer as Mix
+import qualified System.Console.ANSI as ANSI
 
 import Darby.Playlist (Song(..), Playlist, getPlaylist)
 
@@ -67,7 +68,9 @@ playSong song = do
     delayWhile Mix.playingMusic updateCompletion
     Mix.free music
   where
-    updateCompletion = printCompletion (songDuration song)
+    updateCompletion i = do
+        printCompletion (songDuration song) i
+        liftIO $ ANSI.cursorUpLine 1
 
 playPlaylist :: Playlist -> MusicM ()
 playPlaylist = mapM_ playSong . getPlaylist

--- a/src/Darby/Music.hs
+++ b/src/Darby/Music.hs
@@ -43,6 +43,7 @@ playSong :: Song -> MusicM ()
 playSong song = do
     music <- Mix.load (songPath song)
     putTextLn ("Playing: " <> songName song)
+    print (songDuration song)
     Mix.playMusic Mix.Once music
     delayWhile Mix.playingMusic
     Mix.free music

--- a/src/Darby/Music.hs
+++ b/src/Darby/Music.hs
@@ -15,6 +15,7 @@ where
 
 import Relude
 
+import Data.Text (justifyRight)
 import qualified SDL
 import qualified SDL.Mixer as Mix
 
@@ -41,14 +42,28 @@ runMusicM (MusicM action) = do
 -- | Takes a duration and outputs mm:ss format
 durationText :: Integer -> Text
 durationText int =
-    show (div int 60) <> ":" <> show (mod int 60)
+    show (div int 60) 
+    <> ":" 
+    <> justifyRight 2 '0' (show (mod int 60))
+    
+
+{- | Prints the completion status
+
+Takes the total duration of the song, and the current
+amount of seconds passed.
+-}
+printCompletion :: MonadIO m => Integer -> Integer -> m ()
+printCompletion full current = do
+    let fullText = durationText full
+        currentText = durationText current
+    putTextLn (currentText <> " / " <> fullText)
 
 -- | Plays a song until completion, blocking the thread
 playSong :: Song -> MusicM ()
 playSong song = do
     music <- Mix.load (songPath song)
     putTextLn ("Playing: " <> songName song)
-    putTextLn . durationText . songDuration $ song
+    printCompletion (songDuration song) 0
     Mix.playMusic Mix.Once music
     delayWhile Mix.playingMusic
     Mix.free music

--- a/src/Darby/Music.hs
+++ b/src/Darby/Music.hs
@@ -38,12 +38,17 @@ runMusicM (MusicM action) = do
     return a
 
 
+-- | Takes a duration and outputs mm:ss format
+durationText :: Integer -> Text
+durationText int =
+    show (div int 60) <> ":" <> show (mod int 60)
+
 -- | Plays a song until completion, blocking the thread
 playSong :: Song -> MusicM ()
 playSong song = do
     music <- Mix.load (songPath song)
     putTextLn ("Playing: " <> songName song)
-    print (songDuration song)
+    putTextLn . durationText . songDuration $ song
     Mix.playMusic Mix.Once music
     delayWhile Mix.playingMusic
     Mix.free music

--- a/stack.yaml
+++ b/stack.yaml
@@ -3,6 +3,7 @@ resolver: lts-12.2
 extra-deps:
   - base-noprelude-4.11.1.0
   - relude-0.4.0
+  - taglib-0.1.1
 
 ghc-options:
   "$locals": -fhide-source-paths


### PR DESCRIPTION
The current behavior is now to display something like `1:54 / 3:12` when playing a song, and have this update on the same line using ANSI codes.